### PR TITLE
Fix some color codes in ProductDetail components

### DIFF
--- a/front-end/components/ProductDetail/ProductDetail.js
+++ b/front-end/components/ProductDetail/ProductDetail.js
@@ -72,7 +72,7 @@ const ProductDetail = ({
               <View>
                 <Icon
                   name="add"
-                  color="#4396DC"
+                  color={colorCode.blue}
                   size={30}
                   containerStyle={{
                     margin: 0,

--- a/front-end/components/ProductDetailReviews/ProductDetailReviews.js
+++ b/front-end/components/ProductDetailReviews/ProductDetailReviews.js
@@ -172,7 +172,7 @@ const styles = StyleSheet.create({
 
   userReviewTextbox: {
     borderRadius: 6,
-    borderColor: colorCode.lightGray,
+    borderColor: colorCode.veryLightGray,
     borderWidth: 1,
     paddingHorizontal: 10,
     paddingVertical: 5,
@@ -188,7 +188,7 @@ const styles = StyleSheet.create({
   },
 
   btnSubmit: {
-    backgroundColor: '#4396DC',
+    backgroundColor: colorCode.blue,
     borderRadius: 25,
     alignSelf: 'flex-end',
     paddingHorizontal: 24,

--- a/front-end/components/common/Comment.js
+++ b/front-end/components/common/Comment.js
@@ -71,8 +71,8 @@ const Comment = ({
               <Button
                 containerViewStyle={styles.communityReviewBottomBtnCont}
                 buttonStyle={styles.communityReviewBottomBtn}
-                color={colorCode.lightGray}
-                icon={{ name: "favorite-border", color: colorCode.lightGray }}
+                color={colorCode.veryLightGray}
+                icon={{ name: "favorite-border", color: colorCode.veryLightGray }}
                 title={"Helpful (" + helpfulCount + ")"}
                 textStyle={styles.communityReviewBottomBtnTxt}
                 onPress={onPressHelpful}
@@ -91,8 +91,8 @@ const Comment = ({
             <Button
               containerViewStyle={styles.communityReviewBottomBtnCont}
               buttonStyle={styles.communityReviewBottomBtn}
-              color={colorCode.lightGray}
-              icon={{ name: "warning", color: colorCode.lightGray }}
+              color={colorCode.veryLightGray}
+              icon={{ name: "warning", color: colorCode.veryLightGray }}
               title="Report"
               textStyle={styles.communityReviewBottomBtnTxt}
               onPress={onPressReport}

--- a/front-end/utils/colorCode.js
+++ b/front-end/utils/colorCode.js
@@ -3,7 +3,6 @@ export default {
   lightBlue: '#C8EAFF',
   blue: '#4396DC',
   white: '#FFFFFF',
-  lightGray: '#BDBDBD',
   gray: '#828282',
   red: '#EB5757',
   moderateTag: '#4396DC',
@@ -19,6 +18,7 @@ export default {
   lightgray: '#8F8F8F',
   lightLightGray: '#8A8A8F',
   anotherLightGray: '#828282',
+  veryLightGray: '#BDBDBD',
   extremeLightGray: '#E3E3E3',
   black: '#303030'
 };


### PR DESCRIPTION
This will close #185 .

This PR adds color.blue to some properties instead of absolute color code, and change the name of lightGray by veryLightGray, because my "lightGray" can confuse with the other "lightgray".